### PR TITLE
Change return type of Lanczos and Arnoldi algorithms

### DIFF
--- a/include/solve.hpp
+++ b/include/solve.hpp
@@ -68,7 +68,7 @@ void solve_inplace(DynamicVector<T> &x,
     // Lanczos
     template<typename MatrixType, typename T, typename TagType>
     void solve_inplace(DynamicVector<T> &x,
-                       const SymmetricMatrix<MatrixType> &A,
+                       const MatrixType &A,
                        const DynamicVector<T> &b,
                        TagType &tag,
                        const std::size_t &n)
@@ -169,7 +169,7 @@ DynamicVector<T> solve(const MatrixType &A,
 // For Arnoldi
 // For Lanczos
     template<typename MatrixType, typename T, typename TagType>
-    DynamicVector<T> solve(const SymmetricMatrix<MatrixType> &A, const DynamicVector<T> &b, TagType &tag, const std::size_t &n)
+    DynamicVector<T> solve(const MatrixType &A, const DynamicVector<T> &b, TagType &tag, const std::size_t &n)
     {
         if(typeid(tag) == typeid(ArnoldiTag)){
             DynamicVector<T> x(n, 0.0);

--- a/include/solve.hpp
+++ b/include/solve.hpp
@@ -67,8 +67,8 @@ void solve_inplace(DynamicVector<T> &x,
     // For Arnoldi
     // Lanczos
     template<typename MatrixType, typename T, typename TagType>
-    void solve_inplace(DynamicVector<complex<T>> &x,
-                       const MatrixType &A,
+    void solve_inplace(DynamicVector<T> &x,
+                       const SymmetricMatrix<MatrixType> &A,
                        const DynamicVector<T> &b,
                        TagType &tag,
                        const std::size_t &n)
@@ -80,7 +80,6 @@ void solve_inplace(DynamicVector<T> &x,
 
         //Run-time assertions checking conditions that would be problems later anyway
         assert(A.columns() == b.size() && "A and b must have consistent dimensions");
-        assert(x.size() == b.size() && "x and b must be the same length");
         assert(isSymmetric(A) && "A must be a symmetric matrix");
         assert(n >= 1 && "n must be larger than or equal to 1");
 
@@ -170,15 +169,15 @@ DynamicVector<T> solve(const MatrixType &A,
 // For Arnoldi
 // For Lanczos
     template<typename MatrixType, typename T, typename TagType>
-    DynamicVector<complex<T>> solve(const MatrixType &A, const DynamicVector<T> &b, TagType &tag, const std::size_t &n)
+    DynamicVector<T> solve(const SymmetricMatrix<MatrixType> &A, const DynamicVector<T> &b, TagType &tag, const std::size_t &n)
     {
         if(typeid(tag) == typeid(ArnoldiTag)){
-            DynamicVector<complex<T>> x(n, 0.0);
+            DynamicVector<T> x(n, 0.0);
             solve_inplace(x, A, b, tag, n);
             return x;
 
         } else if(typeid(tag) == typeid(LanczosTag)) {
-            DynamicVector<complex<T>> x(n, 0.0);
+            DynamicVector<T> x(n, 0.0);
             solve_inplace(x, A, b, tag, n);
             return x;
         }

--- a/include/solvers/Arnoldi.hpp
+++ b/include/solvers/Arnoldi.hpp
@@ -10,7 +10,6 @@
 #include "IterativeCommon.hpp"
 #include "ArnoldiTag.hpp"
 
-
 BLAZE_NAMESPACE_OPEN
     ITERATIVE_NAMESPACE_OPEN
 
@@ -18,21 +17,20 @@ BLAZE_NAMESPACE_OPEN
 
             template<typename MatrixType, typename T>
             void  solve_impl(
-                    DynamicVector<complex<T>> &x,
-                    const MatrixType &A,
+                    DynamicVector<T> &x,
+                    const SymmetricMatrix<MatrixType> &A,
                     const DynamicVector<T> &b,
                     ArnoldiTag &tag,
                     const std::size_t &n
-                   )
-            {
+                   ) {
 
                 BLAZE_INTERNAL_ASSERT(isSymmetric(A), "A must be a symmetric matrix")
 
                 // n is dimension of Krylov subspace, n >=1;
-               //
+                //
                 BLAZE_INTERNAL_ASSERT(n >= 1, "n must larger than or equal to 1")
 
-               // computes a basis of the n- Krylov subspace of A:
+                // computes a basis of the n- Krylov subspace of A:
                 // the space is spanned by{b, Ab, ..., A^(n-1)b}
                 // Input
                 // A: m * m matrix
@@ -46,11 +44,12 @@ BLAZE_NAMESPACE_OPEN
                 std::size_t m = b.size();
 
                 // Return a vector of eigenvalues
-               
-               // DynamicMatrix<T> Q(m, (n + 1));
-               // DynamicMatrix<T> h((n + 1), n);
-                DynamicMatrix<T> Q(m, n+1);
-                DynamicMatrix<T> h(n+1, n);
+
+                // DynamicMatrix<T> Q(m, (n + 1));
+                // DynamicMatrix<T> h((n + 1), n);
+                DynamicMatrix<T> Q(m, n + 1);
+                DynamicMatrix<T> h(n + 1, n);
+                DynamicVector<complex<double>> x_comp(n);
 
                 // let b be an arbitrary initial vector
                 column(Q, 0) = b / norm(b);
@@ -58,29 +57,29 @@ BLAZE_NAMESPACE_OPEN
                 // the next vector q_k = A* q_k_1
                 DynamicVector<T> v(m);
 
-                for (int k = 0; k < n; ++k ){
+                for (int k = 0; k < n; ++k) {
                     v = declsym(A) * column(Q, k);
 
-                    for (int j = 0; j < k+1; ++j){
-                        h(j,k) = ctrans(column(Q,j)) * v;
-                        v -= h(j,k) * column(Q,j);
+                    for (int j = 0; j < k + 1; ++j) {
+                        h(j, k) = ctrans(column(Q, j)) * v;
+                        v -= h(j, k) * column(Q, j);
                     }
 
-                    h(k+1, k) = norm(v);
+                    h(k + 1, k) = norm(v);
                     // if h(k+1, k) = 0
                     double eps = 1e-12;
-                    if (h(k+1, k) > eps){
-                        column(Q,k+1) = v / h(k+1,k);
-                    }
-                    else{
+                    if (h(k + 1, k) > eps) {
+                        column(Q, k + 1) = v / h(k + 1, k);
+                    } 
+                    else {
                         break;
                     }
 
                 }
 
                 auto sub_h = submatrix( h, 0UL, 0UL, (h.rows()-1), h.columns());
-                eigen(sub_h, x);
-                
+                eigen(sub_h, x_comp);
+                x = real(x_comp);
 
             }; // end solve_imple function
 

--- a/include/solvers/Arnoldi.hpp
+++ b/include/solvers/Arnoldi.hpp
@@ -18,7 +18,7 @@ BLAZE_NAMESPACE_OPEN
             template<typename MatrixType, typename T>
             void  solve_impl(
                     DynamicVector<T> &x,
-                    const SymmetricMatrix<MatrixType> &A,
+                    const MatrixType &A,
                     const DynamicVector<T> &b,
                     ArnoldiTag &tag,
                     const std::size_t &n

--- a/include/solvers/GMRES.hpp
+++ b/include/solvers/GMRES.hpp
@@ -7,7 +7,6 @@
 #ifndef BLAZE_ITERATIVE_GMRES_HPP
 #define BLAZE_ITERATIVE_GMRES_HPP
 
-#include <iostream>
 #include "IterativeCommon.hpp"
 #include "GMRESTag.hpp"
 #include <utility>

--- a/include/solvers/Lanczos.hpp
+++ b/include/solvers/Lanczos.hpp
@@ -7,7 +7,6 @@
 #ifndef BLAZE_ITERATIVE_LANCZOS_HPP
 #define BLAZE_ITERATIVE_LANCZOS_HPP
 
-#include <iostream>
 #include "IterativeCommon.hpp"
 #include "LanczosTag.hpp"
 
@@ -19,8 +18,8 @@ BLAZE_NAMESPACE_OPEN
 
             template<typename MatrixType, typename T>
             void  solve_impl(
-                    DynamicVector<complex<T>> &x,
-                    const MatrixType &A,
+                    DynamicVector<T> &x,
+                    const  SymmetricMatrix<MatrixType> &A,
                     const DynamicVector<T> &b,
                     LanczosTag &tag,
                     const std::size_t &n
@@ -30,7 +29,7 @@ BLAZE_NAMESPACE_OPEN
                 BLAZE_INTERNAL_ASSERT(isSymmetric(A), "A must be a symmetric matrix")
 
                 // n is dimension of Krylov subspace, n >=1;
-                //
+                
                 BLAZE_INTERNAL_ASSERT(n >= 1, "n must larger than or equal to 1")
 
                 // computes a basis of the n- Krylov subspace of A:
@@ -43,13 +42,13 @@ BLAZE_NAMESPACE_OPEN
                 // Q: m * n matrix, the columns are an orthonormal
                 // h: n * n matrix, tridiagonal real symmetric
 
-
                 std::size_t m = A.columns();
                 DynamicVector<T> alpha(n);
                 DynamicVector<T> beta(n);
                 DynamicVector<T> Av(m);
                 DynamicMatrix<T> Q(m, n);
                 DynamicMatrix<T> h(n, n);
+                DynamicVector<complex<double>> x_comp(n);
 
 
              // with an example of a diagonal matrix A
@@ -79,7 +78,8 @@ BLAZE_NAMESPACE_OPEN
                 band<1>(h) = beta_1;
                 band<-1>(h) = beta_1;
 
-                eigen(h, x);
+                eigen(h, x_comp);
+                x = real(x_comp);
 
             }; // end solve_imple function
 

--- a/include/solvers/Lanczos.hpp
+++ b/include/solvers/Lanczos.hpp
@@ -19,7 +19,7 @@ BLAZE_NAMESPACE_OPEN
             template<typename MatrixType, typename T>
             void  solve_impl(
                     DynamicVector<T> &x,
-                    const  SymmetricMatrix<MatrixType> &A,
+                    const  MatrixType &A,
                     const DynamicVector<T> &b,
                     LanczosTag &tag,
                     const std::size_t &n

--- a/tests/main_Arnoldi.cpp
+++ b/tests/main_Arnoldi.cpp
@@ -16,29 +16,24 @@ int main() {
     // Test Arnoldi
 
     std::size_t N = 6;
-    DynamicMatrix<double,columnMajor> A(N,N,0);
+    SymmetricMatrix<DynamicMatrix<double>> A(N);
     band<0>(A) = {0, 1, 2, 3, 4, 100000};
 
     DynamicVector<double> b(N, 1);
-    DynamicVector<complex<double>,columnVector> w(N);
-    DynamicMatrix<complex<double>,rowMajor> V(N,N);
-    DynamicVector<complex<double>,columnVector> w1(N);
-    eigen(A,w,V);
+    DynamicVector<double,columnVector> w(N);
+    DynamicVector<double,columnVector> w1(N);
+    eigen(A,w);
 
     w1 = {w[5],w[0],w[4],w[1],w[2],w[3]};
 
     std::size_t n = N;
     ArnoldiTag tag;
-    DynamicVector<complex<double>,columnVector> w2(n);
-    DynamicMatrix<complex<double>,rowMajor> V2(n,n);
+    DynamicVector<double,columnVector> w2(n);
     w2 = solve(A,b,tag,n);
-
-
-    auto error = real(norm(w1 - w2));
-
-
+    
+    auto error = norm(w1 - w2);
+    
     if (error < EPSILON){
-
         std::cout << " Pass test of Arnoldi" << std::endl;
         return EXIT_SUCCESS;
     } else{

--- a/tests/main_Arnoldi.cpp
+++ b/tests/main_Arnoldi.cpp
@@ -16,22 +16,22 @@ int main() {
     // Test Arnoldi
 
     std::size_t N = 6;
-    SymmetricMatrix<DynamicMatrix<double>> A(N);
+    DynamicMatrix<double,rowMajor> A(N, N, 0.0);
     band<0>(A) = {0, 1, 2, 3, 4, 100000};
-
     DynamicVector<double> b(N, 1);
-    DynamicVector<double,columnVector> w(N);
+    DynamicVector<complex<double>,columnVector> w(N);
     DynamicVector<double,columnVector> w1(N);
+    DynamicVector<double,columnVector> w2(N);
     eigen(A,w);
-
-    w1 = {w[5],w[0],w[4],w[1],w[2],w[3]};
+    w1 = real(w);
+    w2 = {w1[5],w1[0],w1[4],w1[1],w1[2],w1[3]};
 
     std::size_t n = N;
     ArnoldiTag tag;
-    DynamicVector<double,columnVector> w2(n);
-    w2 = solve(A,b,tag,n);
+    DynamicVector<double,columnVector> w3(n);
+    w3 = solve(A,b,tag,n);
     
-    auto error = norm(w1 - w2);
+    auto error = norm(w2 - w3);
     
     if (error < EPSILON){
         std::cout << " Pass test of Arnoldi" << std::endl;

--- a/tests/main_Lanczos.cpp
+++ b/tests/main_Lanczos.cpp
@@ -16,23 +16,22 @@ int main() {
     // Test Lanczos
 
     std::size_t N = 6;
-    DynamicMatrix<double> A(N,N);
+    SymmetricMatrix<DynamicMatrix<double,rowMajor>> A(N);
     band<0>(A) = {0, 1, 2, 3, 4, 100000};
 
     DynamicVector<double> b(N, 1);
-    DynamicVector<complex<double>,columnVector> w(N);
-    DynamicVector<complex<double>,columnVector> w1(N);
+    DynamicVector<double,columnVector> w(N);
+    DynamicVector<double,columnVector> w1(N);
     eigen(A,w);
     w1 = {w[5],w[0],w[4],w[1],w[2],w[3]};
 
     std::size_t n = N;
     LanczosTag tag;
-    DynamicVector<complex<double>,columnVector> w2(n);
+    DynamicVector<double, columnVector> w2(n);
     w2 = solve(A,b,tag,n);
-
-    auto error = real(norm(w1 - w2));
-
-
+    
+    auto error = norm(w1 - w2);
+    
     if (error < EPSILON){
         std::cout << " Pass test of Lanczos" << std::endl;
         return EXIT_SUCCESS;

--- a/tests/main_Lanczos.cpp
+++ b/tests/main_Lanczos.cpp
@@ -16,21 +16,22 @@ int main() {
     // Test Lanczos
 
     std::size_t N = 6;
-    SymmetricMatrix<DynamicMatrix<double,rowMajor>> A(N);
+    DynamicMatrix<double,rowMajor> A(N, N, 0.0);
     band<0>(A) = {0, 1, 2, 3, 4, 100000};
-
     DynamicVector<double> b(N, 1);
-    DynamicVector<double,columnVector> w(N);
+    DynamicVector<complex<double>,columnVector> w(N);
     DynamicVector<double,columnVector> w1(N);
+    DynamicVector<double,columnVector> w2(N);
     eigen(A,w);
-    w1 = {w[5],w[0],w[4],w[1],w[2],w[3]};
+    w1 = real(w);
+    w2 = {w1[5],w1[0],w1[4],w1[1],w1[2],w1[3]};
 
     std::size_t n = N;
     LanczosTag tag;
-    DynamicVector<double, columnVector> w2(n);
-    w2 = solve(A,b,tag,n);
+    DynamicVector<double, columnVector> w3(n);
+    w3 = solve(A,b,tag,n);
     
-    auto error = norm(w1 - w2);
+    auto error = norm(w2 - w3);
     
     if (error < EPSILON){
         std::cout << " Pass test of Lanczos" << std::endl;


### PR DESCRIPTION
Lanczos and Arnoldi algorithms return real eigenvalues instead of complex eigenvalues with zero imaginary parts.